### PR TITLE
Sugestões da banca para análise de versões

### DIFF
--- a/anal/gccver_to_glibcver.py
+++ b/anal/gccver_to_glibcver.py
@@ -16,15 +16,15 @@ def ts2str(ts):
     return datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
 
 
-def get_timespan(package, version, distro):
+def get_timespan(name, version, distro):
     c = conn.cursor()
-    c.execute("SELECT timestamp, distro_release FROM versions "
-              "WHERE package=? AND version=? AND distro=?",
-              (package, version, distro))
+    c.execute("SELECT timestamp, package, distro_release FROM versions "
+              "WHERE name=? AND version=? AND distro=?",
+              (name, version, distro))
     row = c.fetchone()
     if not row:
         return None
-    t1, distro_release = row
+    t1, package, distro_release = row
     c.execute("SELECT timestamp, version FROM versions "
               "WHERE package=? AND distro=? "
               "  AND (distro_release=? OR distro_release IS NULL) "
@@ -35,39 +35,40 @@ def get_timespan(package, version, distro):
     t2, v2 = None, None
     if row:
         t2, v2 = row   # None if open-ended
-    logging.info('get_timespan: %s %s -> %s (%s): %s -> %s',
-                 package,
+    logging.info('get_timespan: %s %s -> %s (%s, %s): %s -> %s',
+                 name,
                  version, v2 or 'None',
                  distro_release or 'None',
+                 package,
                  ts2str(t1),
                  ts2str(t2) if t2 else 'None')
     return t1, t2, distro_release
 
 
-def versions_in_timespan(package, distro, t1, t2, distro_release):
+def versions_in_timespan(name, distro, t1, t2, distro_release):
     vers = set()
     c = conn.cursor()
     c.execute("SELECT version, timestamp FROM versions "
-              "WHERE package=? AND distro=? "
+              "WHERE name=? AND distro=? "
               "  AND (distro_release=? OR distro_release IS NULL) "
               "  AND timestamp<=?"
               "ORDER BY timestamp DESC LIMIT 1",
-              (package, distro, distro_release, t1))
+              (name, distro, distro_release, t1))
     row = c.fetchone()
     if row:
         ver, ts = row
-        logging.info('versions_in_timespan: %s: %s (%s)', package, ver, ts2str(ts))
+        logging.info('versions_in_timespan: %s: %s (%s)', name, ver, ts2str(ts))
         vers.add(ver)
     c.execute("SELECT version, timestamp FROM versions "
-              "WHERE package=? AND distro=? "
+              "WHERE name=? AND distro=? "
               "  AND (distro_release=? OR distro_release IS NULL) "
               "  AND timestamp>? "
               "  AND (timestamp<? OR ? IS NULL)"
               "ORDER BY timestamp ASC",
-              (package, distro, distro_release, t1, t2, t2))
+              (name, distro, distro_release, t1, t2, t2))
     for row in c.fetchmany():
         ver, ts = row
-        logging.info('versions_in_timespan: %s: %s (%s)', package, ver, ts2str(ts))
+        logging.info('versions_in_timespan: %s: %s (%s)', name, ver, ts2str(ts))
         vers.add(ver)
     return vers
 

--- a/anal/plot_hist_diff_changelog.py
+++ b/anal/plot_hist_diff_changelog.py
@@ -16,11 +16,11 @@ with open('allsigs.txt') as f:
     allsigs = set(ver_from_signame(s.strip()) for s in f)
 
 
-def get_timestamp(package, version):
+def get_timestamp(name, version):
     c = conn.cursor()
     c.execute("SELECT timestamp FROM versions "
-              "WHERE package=? AND version=?",
-              (package, version))
+              "WHERE name=? AND version=?",
+              (name, version))
     row = c.fetchone()
     if not row:
         return None

--- a/anal/plot_timeline.py
+++ b/anal/plot_timeline.py
@@ -14,11 +14,11 @@ log_path = '/home/william/ida_logs'
 conn = sqlite3.connect('versions.db')
 
 
-def get_timestamp(package, version):
+def get_timestamp(name, version):
     c = conn.cursor()
     c.execute("SELECT timestamp FROM versions "
-              "WHERE package=? AND version=?",
-              (package, version))
+              "WHERE name=? AND version=?",
+              (name, version))
     row = c.fetchone()
     if not row:
         return None


### PR DESCRIPTION
Leva em conta nome completo do pacote no Debian/Ubuntu, por exemplo `gcc-9` ou `gcc-4.3`. No caso dessas distribuições, isso é importante pois um mesmo *release* pode disponibilizar diferentes pacotes de gcc no repositório, cada qual com uma *major version* diferente.